### PR TITLE
[PR]Refine terminal keymap API with callback configuration and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Minimal helper to run IPython/Jupyter in a terminal split and send code from the
   - `2`: Reload all modules automatically (except excluded); recommended default.
   - `'disable'`: Do not configure or enable autoreload.
 - `multiline_send_mode` (string): How selections/cells are sent. `'exec'` executes a hex-encoded block via `exec()`; `'paste'`(default) sends a plain-text bracketed paste so the console echoes the code like typed.
+- `terminal_keymaps` (function|nil): Extra terminal-mode mappings appended after the defaults when the IPython console buffer opens. Provide a callback `function(set)` where `set(lhs, rhs, opts)` mirrors `vim.keymap.set` (mode/buffer handled automatically). Defaults for the terminal (`<leader>iv`, `<Tab>`, `<C-c>` → interrupt) are created only when `set_default_keymaps` is `true`.
 
 ## Cell Syntax
 
@@ -206,8 +207,9 @@ vim.api.nvim_create_autocmd('FileType', {
     vim.keymap.set('n', '<F5>', ipybridge.run_file, { buffer = true })
     vim.keymap.set('n', '<F6>', ipybridge.debug_file, { buffer = true })
     vim.keymap.set('n', '<leader>r', ipybridge.run_line, { buffer = true })
-    vim.keymap.set('n', '<leader>b', ipybridge.toggle_breakpoint, { buffer = true })
     vim.keymap.set('v', '<leader>r', ipybridge.run_lines, { buffer = true })
+    vim.keymap.set('n', '<leader>b', ipybridge.toggle_breakpoint, { buffer = true })
+    vim.keymap.set('n', '<leader>B', ipybridge.set_conditional_breakpoint, { buffer = true })
     vim.keymap.set('n', '<F9>', ipybridge.run_line, { buffer = true })
     vim.keymap.set('v', '<F9>', ipybridge.run_lines, { buffer = true })
     vim.keymap.set('n', '<F10>', ipybridge.debug_step_over, { buffer = true })
@@ -219,7 +221,16 @@ vim.api.nvim_create_autocmd('FileType', {
     vim.keymap.set('v', ']c', ipybridge.down_cell, { buffer = true })
     vim.keymap.set('v', '[c', ipybridge.up_cell,   { buffer = true })
     -- In the terminal buffer, set this (example):
-    -- vim.keymap.set('t', '<leader>iv', ipybridge.goto_vi, { buffer = <ipy_bufnr> })
+    -- Additional terminal keymaps can be managed via the `terminal_keymaps` option.
+  end,
+})
+
+-- Example: map key inside the IPython terminal to the interrupt helper.
+require('ipybridge').setup({
+  terminal_keymaps = function(set)
+    local ipy = require('ipybridge')
+    set('<C-c>', ipy.interrupt, { desc = 'IPy: Keyboard interrupt' })
+    set('<leader>iv', ipy.goto_vi, { desc = 'IPy: Back to editor' })
   end,
 })
 ```

--- a/lua/ipybridge/init.lua
+++ b/lua/ipybridge/init.lua
@@ -344,6 +344,8 @@ M.config = {
 	-- 'paste' : send as plain text using bracketed paste so the console shows
 	--           the code exactly as if it was typed (Spyder-like echo).
 	multiline_send_mode = "paste",
+	-- Extra terminal-mode keymaps applied after the IPython console buffer is created.
+	terminal_keymaps = nil,
 }
 
 local function get_start_line_cell(idx_seed)
@@ -385,6 +387,7 @@ M.setup = function(config)
 			var_repr_limit = { config.var_repr_limit, "n", true },
 			python_cmd = { config.python_cmd, "s", true },
 			debugfile_save_before_run = { config.debugfile_save_before_run, "b", true },
+			terminal_keymaps = { config.terminal_keymaps, "function", true },
 		})
 	end
 	M.config = vim.tbl_deep_extend("force", M.config, config or {})
@@ -486,6 +489,7 @@ session_manager = SessionManager.new({
 	exec_with_pipeline = exec_with_pipeline,
 	term_send = term_send,
 	warn_user = warn_user,
+	keymaps = keymaps,
 	is_windows = is_windows,
 })
 

--- a/lua/ipybridge/keymaps.lua
+++ b/lua/ipybridge/keymaps.lua
@@ -5,6 +5,16 @@ local api = vim.api
 
 local M = {}
 
+---Apply the default terminal-mode mappings using the provided setter helper.
+---@param set fun(lhs:string, rhs:(string|function), opts?:table|string)
+---@param opts table|nil
+function M.apply_terminal_defaults(set, opts)
+	opts = opts or {}
+	set("<leader>iv", opts.goto_vi, { desc = opts.goto_desc })
+	set("<Tab>", opts.handle_tab, { desc = opts.tab_desc })
+	set("<C-c>", opts.interrupt, { desc = opts.interrupt_desc })
+end
+
 -- Apply a set of sensible default keymaps and user commands.
 function M.apply_defaults()
 	local my = require("ipybridge")
@@ -21,9 +31,6 @@ function M.apply_defaults()
 
 	-- Global: back to editor
 	pcall(vim.keymap.set, "n", "<leader>iv", my.goto_vi, { silent = true, desc = "IPy: Back to editor" })
-	pcall(vim.keymap.set, "t", "<leader>iv", function()
-		my.goto_vi()
-	end, { silent = true, desc = "IPy: Back to editor" })
 
 	-- Variable explorer commands (global)
 	pcall(vim.keymap.set, "n", "<leader>vx", function()

--- a/lua/ipybridge/session.lua
+++ b/lua/ipybridge/session.lua
@@ -28,6 +28,7 @@ function Session.new(opts)
 	self.exec_with_pipeline = dependency(opts, "exec_with_pipeline")
 	self.term_send = dependency(opts, "term_send")
 	self.warn_user = dependency(opts, "warn_user")
+	self.keymaps = dependency(opts, "keymaps")
 	self.is_windows = opts.is_windows and true or false
 	return self
 end
@@ -120,19 +121,33 @@ function Session:setup_terminal_keymaps(state)
 			return
 		end
 		local buf = term.buf_id
-		local goto_vi = state.goto_vi
-		vim.keymap.set("t", "<leader>iv", function()
-			if type(goto_vi) == "function" then
-				goto_vi()
+		local function define_terminal_map(lhs, rhs, opts)
+			local options = type(opts) == "table" and vim.deepcopy(opts) or {}
+			options.buffer = buf
+			if options.silent == nil then
+				options.silent = true
 			end
-		end, { buffer = buf, silent = true, desc = "IPy: Back to editor" })
+			vim.keymap.set("t", lhs, rhs, options)
+		end
+
 		self.cmp_bridge.ensure()
-		vim.keymap.set(
-			"t",
-			"<Tab>",
-			self.handle_terminal_tab,
-			{ buffer = buf, silent = true, desc = "IPy: Debug completion trigger" }
-		)
+
+		local config = state.config or {}
+		if config.set_default_keymaps ~= false then
+			self.keymaps.apply_terminal_defaults(define_terminal_map, {
+				goto_vi = state.goto_vi,
+				goto_desc = "IPy: Back to editor",
+				handle_tab = self.handle_terminal_tab,
+				tab_desc = "IPy: Debug completion trigger",
+				interrupt = state.interrupt,
+				interrupt_desc = "IPy: Keyboard interrupt",
+			})
+		end
+
+		local custom_maps = config.terminal_keymaps
+		if type(custom_maps) == "function" then
+			custom_maps(define_terminal_map)
+		end
 	end)
 end
 
@@ -268,8 +283,8 @@ function Session:run_deferred_startup(state, opts)
 					local r = tostring(reason or "")
 					self.warn_user(
 						"ipybridge: failed to run startup script via ZMQ; replaying in terminal ("
-							.. (r ~= "" and r or "unknown")
-							.. ")"
+						.. (r ~= "" and r or "unknown")
+						.. ")"
 					)
 					self.term_send(stmt)
 				end,

--- a/tests/spec/session_spec.lua
+++ b/tests/spec/session_spec.lua
@@ -56,6 +56,13 @@ local function base_deps()
 			attach_session = function(_) end,
 			sync_with_kernel = function() end,
 		},
+		keymaps = {
+			apply_terminal_defaults = function(set, opts)
+				set("<leader>iv", opts.goto_vi, { desc = opts.goto_desc })
+				set("<Tab>", opts.handle_tab, { desc = opts.tab_desc })
+				set("<C-c>", opts.interrupt, { desc = opts.interrupt_desc })
+			end,
+		},
 		fs = {
 			joinpath = function(...)
 				local parts = { ... }
@@ -142,6 +149,32 @@ local function posix_vim(py_path)
 	}
 end
 
+local function extend_with_keymap(env)
+	local function deepcopy(value)
+		if type(value) ~= "table" then
+			return value
+		end
+		local copy = {}
+		for k, v in pairs(value) do
+			copy[k] = deepcopy(v)
+		end
+		return copy
+	end
+	env.deepcopy = deepcopy
+	env.keymaps = {}
+	env.keymap = {
+		set = function(mode, lhs, rhs, opts)
+			table.insert(env.keymaps, {
+				mode = mode,
+				lhs = lhs,
+				rhs = rhs,
+				opts = opts,
+			})
+		end,
+	}
+	return env
+end
+
 it("build_console_env merges pythonpath on Windows", function()
 	_G.vim = windows_vim("C:\\helpers;C:\\existing")
 	local session = fresh_session()
@@ -183,6 +216,89 @@ it("build_console_env sets pythonpath when missing on posix", function()
 		string.format("pythonpath should be set to helper root, got %s", tostring(env.PYTHONPATH))
 	)
 	assert(env.IPYBRIDGE_BREAKPOINT_FILE == nil, "breakpoint file should be absent")
+end)
+
+it("setup_terminal_keymaps applies defaults and custom mappings", function()
+	local vim_env = extend_with_keymap(posix_vim(""))
+	vim_env.tbl_extend = function(_, base, extra)
+		local merged = {}
+		for k, v in pairs(base or {}) do
+			merged[k] = v
+		end
+		for k, v in pairs(extra or {}) do
+			merged[k] = v
+		end
+		return merged
+	end
+	_G.vim = vim_env
+	local cmp_calls = 0
+	local session = fresh_session({
+		deps = {
+			cmp_bridge = {
+				ensure = function()
+					cmp_calls = cmp_calls + 1
+				end,
+			},
+		},
+	})
+	local invoked = { goto_vi = 0 }
+	local state = {
+		term_instance = { buf_id = 41 },
+	config = {
+		set_default_keymaps = true,
+		terminal_keymaps = function(set)
+			set("<C-z>", function()
+				invoked.custom = true
+			end, { silent = false, desc = "Custom" })
+		end,
+	},
+		goto_vi = function()
+			invoked.goto_vi = invoked.goto_vi + 1
+		end,
+		interrupt = function() end,
+	}
+	session:setup_terminal_keymaps(state)
+	assert(cmp_calls == 1, "cmp bridge ensure should be called once")
+	local seen = {}
+	for _, map in ipairs(vim_env.keymaps) do
+		seen[map.lhs] = map
+		assert(map.mode == "t", string.format("mapping %s should target terminal mode", tostring(map.lhs)))
+		assert(map.opts and map.opts.buffer == 41, "buffer-local mapping expected")
+	end
+	assert(seen["<leader>iv"], "default <leader>iv mapping missing")
+	assert(seen["<Tab>"], "default <Tab> mapping missing")
+	local ctrl_c = seen["<C-c>"]
+	assert(ctrl_c, "default <C-c> mapping missing")
+	assert(ctrl_c.opts.silent == true, "default interrupt mapping should stay silent")
+	assert(ctrl_c.opts.desc == "IPy: Keyboard interrupt", "default interrupt mapping should set description")
+	local custom = seen["<C-z>"]
+	assert(custom, "custom <C-z> mapping missing")
+	assert(custom.opts.silent == false, "custom mapping should keep explicit silent option")
+	assert(custom.opts.desc == "Custom", "custom mapping should keep description")
+end)
+
+it("setup_terminal_keymaps skips defaults when disabled", function()
+	local vim_env = extend_with_keymap(posix_vim(""))
+	_G.vim = vim_env
+	local session = fresh_session()
+	local state = {
+		term_instance = { buf_id = 99 },
+	config = {
+		set_default_keymaps = false,
+		terminal_keymaps = function(set)
+			set("<C-x>", "<C-x>", { desc = "noop" })
+		end,
+	},
+	}
+	session:setup_terminal_keymaps(state)
+	local seen = {}
+	for _, map in ipairs(vim_env.keymaps) do
+		seen[map.lhs] = map
+	end
+	assert(seen["<C-x>"], "custom map should be applied when defaults disabled")
+	assert(not seen["<leader>iv"], "default <leader>iv should not be applied when disabled")
+	assert(not seen["<Tab>"], "default <Tab> should not be applied when disabled")
+	assert(not seen["<C-c>"], "default <C-c> should not be applied when disabled")
 end)
 
 it("collect_startup_instructions assembles warmup and startup script", function()


### PR DESCRIPTION
## Summary
- require `terminal_keymaps` to be a callback that receives a buffer-scoped `set` helper
- move the default terminal mappings into a dedicated helper and simplify their application
- update the docs with callback examples and reorganize breakpoint mappings in the manual setup snippet
- extend tests to cover default and custom terminal keymap registration

Even though you can run something like
```lua
vim.keymap.set("t", "<C-c>", require("ipybridge").interrupt, { buffer = false, desc = "Keyboard Interrupt" })
```

it is risky because it installs a global terminal mapping that affects every terminal buffer and bypasses the lifecycle checks that ipybridge performs. The new terminal_keymaps callback only touches ipybridge’s buffer, survives terminal restarts, and keeps descriptions centralized. Please use that API instead of setting raw global terminal mappings.

fixes #5 
