### PR TITLE
[PR]Add debug sign module for current line

### DIFF
--- a/lua/ipybridge/debug_sign.lua
+++ b/lua/ipybridge/debug_sign.lua
@@ -1,0 +1,84 @@
+local vim = vim
+local api = vim.api
+local fn = vim.fn
+
+local SIGN_GROUP = "IpybridgeDebugLine"
+local SIGN_NAME = "IpybridgeDebugArrow"
+local SIGN_ID = 90210
+local DEBUG_SIGNCOLUMN = "yes:3"
+
+local state = {
+	defined = false,
+	bufnr = nil,
+	lnum = nil,
+	win = nil,
+	prev_signcolumn = nil,
+}
+
+local function ensure_defined()
+	if state.defined then
+		return
+	end
+	state.defined = true
+	pcall(api.nvim_set_hl, 0, "IpybridgeDebugArrow", { default = true, link = "DiagnosticHint" })
+	pcall(fn.sign_define, SIGN_NAME, { text = "=>", texthl = "IpybridgeDebugArrow", numhl = "" })
+end
+
+local function ensure_signcolumn(win)
+	if type(win) ~= "number" or not api.nvim_win_is_valid(win) then
+		return
+	end
+	local current = vim.api.nvim_get_option_value("signcolumn", { scope = "local", win = win })
+	if state.win ~= win then
+		if state.win and api.nvim_win_is_valid(state.win) and state.prev_signcolumn ~= nil then
+			pcall(vim.api.nvim_set_option_value, "signcolumn", state.prev_signcolumn, { scope = "local", win = state.win })
+		end
+		state.win = win
+		state.prev_signcolumn = current
+	elseif state.prev_signcolumn == nil then
+		state.prev_signcolumn = current
+	end
+	if current ~= DEBUG_SIGNCOLUMN then
+		pcall(vim.api.nvim_set_option_value, "signcolumn", DEBUG_SIGNCOLUMN, { scope = "local", win = win })
+	end
+end
+
+local M = {}
+
+function M.place(bufnr, lnum, win)
+	if type(bufnr) ~= "number" or type(lnum) ~= "number" then
+		return
+	end
+	ensure_defined()
+	ensure_signcolumn(win)
+	pcall(fn.sign_unplace, SIGN_GROUP)
+	local ok = pcall(fn.sign_place, SIGN_ID, SIGN_GROUP, SIGN_NAME, bufnr, {
+		lnum = lnum,
+		priority = 100,
+	})
+	if ok then
+		state.bufnr = bufnr
+		state.lnum = lnum
+	else
+		state.bufnr = nil
+		state.lnum = nil
+	end
+end
+
+function M.clear(opts)
+	opts = type(opts) == "table" and opts or {}
+	local restore = opts.restore_signcolumn
+	if restore == nil then
+		restore = true
+	end
+	state.bufnr = nil
+	state.lnum = nil
+	pcall(fn.sign_unplace, SIGN_GROUP)
+	if restore and state.win and api.nvim_win_is_valid(state.win) and state.prev_signcolumn ~= nil then
+		pcall(vim.api.nvim_set_option_value, "signcolumn", state.prev_signcolumn, { scope = "local", win = state.win })
+		state.win = nil
+		state.prev_signcolumn = nil
+	end
+end
+
+return M

--- a/lua/ipybridge/init.lua
+++ b/lua/ipybridge/init.lua
@@ -18,6 +18,7 @@ local debug_vars = require("ipybridge.debug_vars")
 local breakpoints = require("ipybridge.breakpoints")
 local cmp_bridge = require("ipybridge.cmp_bridge")
 local debug_completion = require("ipybridge.debug_completion")
+local debug_sign = require("ipybridge.debug_sign")
 local Executor = require("ipybridge.executor")
 local SessionManager = require("ipybridge.session")
 local inspect = vim.inspect
@@ -147,14 +148,21 @@ local function handle_terminal_tab()
 	api.nvim_feedkeys(literal_tab, "tn", false)
 end
 
--- Reset debugger bookkeeping so UI can return to normal execution state.
-local function clear_debug_state()
+---Reset debugger bookkeeping so UI can return to normal execution state.
+---@param opts? table
+local function clear_debug_state(opts)
+	opts = type(opts) == "table" and opts or {}
+	local restore_signcolumn = opts.restore_signcolumn
+	if restore_signcolumn == nil then
+		restore_signcolumn = true
+	end
 	if type(M._debug_generation) == "number" and M._debug_generation > 0 then
 		M._debug_generation_complete = M._debug_generation
 	end
 	M._debug_active = false
 	M._debug_status_active = false
 	M._debug_window = nil
+	debug_sign.clear({ restore_signcolumn = restore_signcolumn })
 	prompt_buffer = ""
 end
 
@@ -849,7 +857,7 @@ local function send_debug_command(cmd, opts)
 	end
 	term_send_debug(cmd)
 	if opts and opts.deactivate then
-		clear_debug_state()
+		clear_debug_state({ restore_signcolumn = opts.restore_signcolumn })
 	end
 end
 
@@ -870,7 +878,7 @@ end
 
 ---Debugger continue (F12 equivalent).
 M.debug_continue = function()
-	send_debug_command("!continue", { deactivate = true })
+	send_debug_command("!continue", { deactivate = true, restore_signcolumn = false })
 end
 
 local function clamp_cursor_line(bufnr, line)
@@ -988,6 +996,7 @@ function M.on_debug_location(info)
 		pcall(vim.cmd, "normal! zv")
 		pcall(vim.cmd, "normal! zz")
 	end)
+	debug_sign.place(bufnr, line, target_win)
 	M._debug_window = target_win
 	local was_debug = M._debug_active
 	M._debug_active = true

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -16,6 +16,7 @@ local specs = {
 	"tests.spec.zmq_client_spec",
 	"tests.spec.data_viewer_spec",
 	"tests.spec.var_explorer_spec",
+	"tests.spec.debug_sign_spec",
 	"tests.spec.debug_scope_spec",
 }
 

--- a/tests/spec/debug_sign_spec.lua
+++ b/tests/spec/debug_sign_spec.lua
@@ -1,0 +1,166 @@
+package.path = table.concat({
+	"tests/?.lua",
+	"tests/?/init.lua",
+	"lua/?.lua",
+	"lua/?/init.lua",
+	package.path,
+}, ";")
+
+local results = {}
+
+local function record(name, ok, err)
+	table.insert(results, { name = name, ok = ok, err = err })
+	if ok then
+		io.write(string.format("[PASS] %s\n", name))
+	else
+		io.write(string.format("[FAIL] %s: %s\n", name, err))
+	end
+end
+
+local function it(name, fn)
+	local ok, err = pcall(fn)
+	record(name, ok, err)
+end
+
+local function expect(cond, message)
+	if not cond then
+		error(message or "expectation failed")
+	end
+end
+
+local function with_stubbed_vim(run)
+	local original_vim = _G.vim
+	local api_calls = {
+		set_option_value = {},
+		get_option_value = {},
+	}
+	local fn_calls = {
+		sign_define = {},
+		sign_place = {},
+		sign_unplace = {},
+	}
+	local windows = {}
+
+	local function register_window(win, opts)
+		windows[win] = {
+			valid = opts.valid ~= false,
+			signcolumn = opts.signcolumn or "auto",
+		}
+	end
+
+	local vim_stub = {
+		api = {
+			nvim_set_option_value = function(name, value, opts)
+				table.insert(api_calls.set_option_value, { name = name, value = value, opts = opts })
+				if name == "signcolumn" and opts and opts.win and windows[opts.win] then
+					windows[opts.win].signcolumn = value
+				end
+			end,
+			nvim_get_option_value = function(name, opts)
+				table.insert(api_calls.get_option_value, { name = name, opts = opts })
+				if name == "signcolumn" and opts and opts.win and windows[opts.win] then
+					return windows[opts.win].signcolumn
+				end
+				return "auto"
+			end,
+			nvim_win_is_valid = function(win)
+				return windows[win] and windows[win].valid or false
+			end,
+		},
+		fn = {
+			sign_define = function(name, opts)
+				table.insert(fn_calls.sign_define, { name = name, opts = opts })
+			end,
+			sign_place = function(id, group, name, bufnr, opts)
+				table.insert(fn_calls.sign_place, { id = id, group = group, name = name, bufnr = bufnr, opts = opts })
+				return id
+			end,
+			sign_unplace = function(group)
+				table.insert(fn_calls.sign_unplace, { group = group })
+			end,
+		},
+	}
+
+	_G.vim = vim_stub
+
+	register_window(10, { signcolumn = "auto:1" })
+	register_window(11, { valid = false })
+
+	package.loaded["ipybridge.debug_sign"] = nil
+	local debug_sign = require("ipybridge.debug_sign")
+
+	local status, err = pcall(run, {
+		debug_sign = debug_sign,
+		api_calls = api_calls,
+		fn_calls = fn_calls,
+		register_window = register_window,
+	})
+
+	_G.vim = original_vim
+
+	if not status then
+		error(err)
+	end
+end
+
+it("places sign and widens signcolumn", function()
+	with_stubbed_vim(function(ctx)
+		local debug_sign = ctx.debug_sign
+		debug_sign.place(3, 42, 10)
+		expect(#ctx.fn_calls.sign_define == 1, "sign should define once on first use")
+		expect(#ctx.fn_calls.sign_unplace == 1, "sign_unplace should fire before placement")
+		expect(#ctx.fn_calls.sign_place == 1, "sign_place not invoked")
+		local placed = ctx.fn_calls.sign_place[1]
+		expect(placed.group == "IpybridgeDebugLine", "group mismatch")
+		expect(placed.opts.lnum == 42, "line mismatch")
+		expect(placed.opts.priority == 100, "priority unexpected")
+		expect(#ctx.api_calls.set_option_value >= 1, "signcolumn not adjusted")
+		expect(ctx.api_calls.set_option_value[#ctx.api_calls.set_option_value].value == "yes:3", "signcolumn should widen to yes:3")
+	end)
+end)
+
+it("clears sign and restores previous signcolumn", function()
+	with_stubbed_vim(function(ctx)
+		local debug_sign = ctx.debug_sign
+		debug_sign.place(2, 5, 10)
+		ctx.api_calls.set_option_value = {}
+		debug_sign.clear()
+		expect(#ctx.fn_calls.sign_unplace >= 2, "sign should unplace during clear")
+		expect(#ctx.api_calls.set_option_value >= 1, "clear should touch signcolumn")
+		local restore = ctx.api_calls.set_option_value[#ctx.api_calls.set_option_value]
+		expect(restore.value == "auto:1", "should restore original signcolumn width")
+	end)
+end)
+
+it("can keep signcolumn pinned between breakpoints", function()
+	with_stubbed_vim(function(ctx)
+		local debug_sign = ctx.debug_sign
+		debug_sign.place(4, 8, 10)
+		ctx.api_calls.set_option_value = {}
+		debug_sign.clear({ restore_signcolumn = false })
+		expect(#ctx.api_calls.set_option_value == 0, "should not restore signcolumn when told to keep width")
+		local placed_before = #ctx.fn_calls.sign_place
+		debug_sign.place(4, 9, 10)
+		expect(#ctx.fn_calls.sign_place == placed_before + 1, "should place new sign after breakpoint resumes")
+		expect(#ctx.api_calls.set_option_value == 0, "signcolumn already pinned; no additional width change expected")
+		ctx.api_calls.set_option_value = {}
+		debug_sign.clear()
+		expect(#ctx.api_calls.set_option_value >= 1, "final clear should restore signcolumn")
+		local restore = ctx.api_calls.set_option_value[#ctx.api_calls.set_option_value]
+		expect(restore.value == "auto:1", "final clear must return signcolumn to original width")
+	end)
+end)
+
+local all_ok = true
+for _, result in ipairs(results) do
+	if not result.ok then
+		all_ok = false
+		break
+	end
+end
+
+if not all_ok then
+	error("debug_sign_spec failed")
+end
+
+return true


### PR DESCRIPTION
### Summary
- Extract the debug-line indicator into ipybridge.debug_sign so arrow placement and cleanup stay isolated from init.lua.
- Ensure the signcolumn widens when the indicator is shown and reverts to its previous setting once debugging ends.

fixes #8 