### PR TITLE
[PR]Improve startup error messages with dependency checks

### DIFF
--- a/lua/ipybridge/session.lua
+++ b/lua/ipybridge/session.lua
@@ -325,11 +325,41 @@ end
 ---@param state table
 ---@param go_back boolean|nil
 ---@param cb function|nil
+---Open the terminal session.
+---@param state table
+---@param go_back boolean|nil
+---@param cb function|nil
+
+function Session:_notify_missing_deps(python_cmd, context, modules)
+	-- Check for missing python dependencies and notify the user if any are found.
+	-- This is only called when a startup process fails, so we don't slow down the happy path.
+	local missing = self.utils.check_python_deps(python_cmd, modules)
+	if missing and #missing > 0 then
+		local msg = string.format(
+			"ipybridge: %s. Missing packages: %s. You may need to run: %s -m pip install %s",
+			context,
+			table.concat(missing, ", "),
+			python_cmd,
+			table.concat(missing, " ")
+		)
+		vim.notify(msg, vim.log.levels.ERROR)
+		return true -- notification was sent
+	end
+	return false -- no missing dependencies found
+end
+
 function Session:open(state, go_back, cb)
 	local cwd = self.fn.getcwd()
-	self.kernel.ensure(state.config.python_cmd, function(ok, conn_file)
+	local python_cmd = state.config.python_cmd
+	local core_deps = { "ipykernel", "jupyter_client", "ipython" }
+	local zmq_deps = { "zmq" }
+
+	self.kernel.ensure(python_cmd, function(ok, conn_file)
 		if not ok then
-			vim.notify("ipybridge: failed to start Jupyter kernel", vim.log.levels.ERROR)
+			local notified = self:_notify_missing_deps(python_cmd, "failed to start Jupyter kernel", core_deps)
+			if not notified then
+				vim.notify("ipybridge: failed to start Jupyter kernel", vim.log.levels.ERROR)
+			end
 			if cb then
 				cb(false)
 			end
@@ -353,7 +383,10 @@ function Session:open(state, go_back, cb)
 				return
 			end
 			vim.schedule(function()
-				vim.notify("ipybridge: failed to start ZMQ backend", vim.log.levels.WARN)
+				local notified = self:_notify_missing_deps(python_cmd, "failed to start ZMQ backend", zmq_deps)
+				if not notified then
+					vim.notify("ipybridge: failed to start ZMQ backend", vim.log.levels.WARN)
+				end
 			end)
 		end)
 

--- a/lua/ipybridge/utils.lua
+++ b/lua/ipybridge/utils.lua
@@ -109,4 +109,40 @@ function M.paste_block(lines_tbl)
 	return "\x1b[200~" .. body .. "\n\x1b[201~\n"
 end
 
+-- Check for missing python dependencies.
+-- Returns a table of missing modules, or nil if all are present.
+function M.check_python_deps(python_cmd, modules)
+	local py_module = require("ipybridge.py_module")
+	local ok_path, script_path = pcall(py_module.path, "check_deps.py")
+	if not ok_path or not script_path then
+		return nil, "could not find check_deps.py"
+	end
+
+	local cmd = { python_cmd, script_path }
+	vim.list_extend(cmd, modules)
+
+	local output = fn.system(cmd)
+	if vim.v.shell_error ~= 0 then
+		-- Fallback to assuming dependencies are present if the check script fails
+		return nil
+	end
+
+	if output == "" then
+		return nil
+	end
+
+	local missing = {}
+	for s in vim.gsplit(output, "\n") do
+		if s ~= "" then
+			table.insert(missing, s)
+		end
+	end
+
+	if #missing > 0 then
+		return missing
+	end
+
+	return nil
+end
+
 return M

--- a/python/check_deps.py
+++ b/python/check_deps.py
@@ -1,0 +1,18 @@
+# Simple dependency checker for ipybridge.
+# Given a list of module names as command-line arguments, this script tries to
+# import each one and prints the names of any that fail to stdout.
+
+import sys
+import importlib
+
+if __name__ == "__main__":
+    missing = []
+    for mod in sys.argv[1:]:
+        try:
+            importlib.import_module(mod)
+        except ImportError:
+            missing.append(mod)
+
+    if missing:
+        # Print one per line so it's easy to parse from Lua.
+        print("\n".join(missing))


### PR DESCRIPTION
When the Jupyter kernel or ZMQ backend fails to start, the plugin currently displays a generic error message like failed to start Jupyter kernel. This leaves users to guess whether the cause is a configuration issue or missing Python dependencies.

This dependency check is only performed upon failure, so it does not add any overhead to the startup time for correctly configured environments.

fixes #17 