### PR TITLE
[PR]Clear terminal input before sending commands

### DIFF
--- a/lua/ipybridge/core/terminal.lua
+++ b/lua/ipybridge/core/terminal.lua
@@ -3,6 +3,7 @@
 -- Keeps a small surface for terminal lifecycle and send helpers.
 
 local Terminal = {}
+local CTRL_U = string.char(21)
 
 ---Build terminal helpers for opening and sending input to IPython.
 ---@param ctx table
@@ -37,7 +38,7 @@ function Terminal.new(ctx)
 		end)
 	end
 
-	---Send a payload to the terminal and append a newline.
+	---Send a payload to the terminal after clearing the input line, then append a newline.
 	---@param payload string
 	local function term_send(payload)
 		if not state.term_instance then
@@ -49,6 +50,7 @@ function Terminal.new(ctx)
 		if payload == "" then
 			return
 		end
+		state.term_instance:send(CTRL_U)
 		state.term_instance:send(payload)
 		-- Defer the newline slightly so terminals that need a delay behave consistently.
 		vim.defer_fn(function()

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -10,6 +10,7 @@ package.path = table.concat({
 
 local specs = {
 	"tests.spec.dispatch_spec",
+	"tests.spec.terminal_spec",
 	"tests.spec.term_ipy_spec",
 	"tests.spec.utils_spec",
 	"tests.spec.sync_controller_spec",

--- a/tests/spec/terminal_spec.lua
+++ b/tests/spec/terminal_spec.lua
@@ -1,0 +1,80 @@
+-- Specs covering core terminal helpers (input clearing and send order).
+package.path = table.concat({
+	"tests/?.lua",
+	"tests/?/init.lua",
+	"lua/?.lua",
+	"lua/?/init.lua",
+	package.path,
+}, ";")
+
+local mock_vim = require("tests.helpers.mock_vim")
+
+local results = {}
+
+local function record(name, ok, err)
+	table.insert(results, { name = name, ok = ok, err = err })
+	if ok then
+		io.write(string.format("[PASS] %s\n", name))
+	else
+		io.write(string.format("[FAIL] %s: %s\n", name, err))
+	end
+end
+
+local function it(name, fn)
+	local ok, err = pcall(fn)
+	record(name, ok, err)
+end
+
+local function fresh_terminal()
+	package.loaded["ipybridge.core.terminal"] = nil
+	local env = mock_vim.new()
+	_G.vim = env.vim
+	vim.defer_fn = function(cb, _)
+		cb()
+	end
+	local sent = {}
+	local state = {
+		term_instance = {
+			send = function(_, payload)
+				table.insert(sent, payload)
+			end,
+			job_id = 1,
+		},
+	}
+	local terminal = require("ipybridge.core.terminal").new({
+		state = state,
+		is_open = function()
+			return true
+		end,
+	})
+	return terminal, sent
+end
+
+it("clears the input line before sending payload", function()
+	local terminal, sent = fresh_terminal()
+	terminal.term_send("print(1)")
+	assert(#sent == 3, "expected clear, payload, and newline")
+	assert(sent[1] == string.char(21), "expected Ctrl+U clear sequence")
+	assert(sent[2] == "print(1)", "payload should follow the clear sequence")
+	assert(sent[3] == "\n", "newline should be sent last")
+end)
+
+it("skips sending when payload is empty", function()
+	local terminal, sent = fresh_terminal()
+	terminal.term_send("")
+	assert(#sent == 0, "no output should be sent for empty payloads")
+end)
+
+local all_ok = true
+for _, result in ipairs(results) do
+	if not result.ok then
+		all_ok = false
+		break
+	end
+end
+
+if not all_ok then
+	error("terminal_spec failed")
+end
+
+return true


### PR DESCRIPTION
- send Ctrl+U before payload in term_send to clear stale input
- add a spec for terminal send ordering
- register the new spec in the test runner

fixes #22 