### PR TITLE
[PR]Add terminal_winfixbuf option to pin terminal window

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ require("ipybridge").setup({
         startup_script = "import_in_console.py", -- looked up in CWD
         sleep_ms_after_open = 1000,      -- defer init to allow IPython to start
         set_default_keymaps = true,      -- applies by default (can set false)
+        terminal_winfixbuf = false,      -- keep terminal window pinned to its buffer
 
         -- Matplotlib backend
         matplotlib_backend = nil,        -- e.g. 'qt', 'inline', 'macosx', 'tk', 'agg'
@@ -116,6 +117,7 @@ require("ipybridge").setup({
 - `startup_script` (string): If this file exists under current working directory, `ipython -i <startup_script>` is used.
 - `sleep_ms_after_open` (number): Milliseconds to wait (non-blocking) before running initial setup such as `%matplotlib` or `%load_ext autoreload`.
 - `set_default_keymaps` (boolean, default: `true`): Apply buffer-local keymaps for Python files only.
+- `terminal_winfixbuf` (boolean, default: `false`): Lock the terminal window to its buffer (`winfixbuf`) so `:edit` won't replace it.
 
 ### Additional options
 
@@ -141,6 +143,7 @@ require("ipybridge").setup({
   - `2`: Reload all modules automatically (except excluded); recommended default.
   - `'disable'`: Do not configure or enable autoreload.
 - `terminal_keymaps` (function|nil): Extra terminal-mode mappings appended after the defaults when the IPython console buffer opens. Provide a callback `function(set)` where `set(lhs, rhs, opts)` mirrors `vim.keymap.set` (mode/buffer handled automatically). Defaults for the terminal (`<leader>iv`, `<leader>ir`, `<Tab>`, `<C-c>` -> interrupt) are created only when `set_default_keymaps` is `true`.
+- `terminal_winfixbuf` (boolean): Prevent terminal window buffer replacement by enabling `winfixbuf`.
 
 
 ## API

--- a/lua/ipybridge/init.lua
+++ b/lua/ipybridge/init.lua
@@ -235,6 +235,8 @@ M.config = {
 	autoreload = 2,
 	-- Extra terminal-mode keymaps applied after the IPython console buffer is created.
 	terminal_keymaps = nil,
+	-- Lock the terminal window to its buffer to prevent accidental replacement.
+	terminal_winfixbuf = false,
 	completion = {
 		engine_priority = vim.deepcopy(cmp_constants.default_engine_priority),
 	},
@@ -278,6 +280,7 @@ M.setup = function(config)
 			debugcell_save_before_run = { config.debugcell_save_before_run, "b", true },
 			debugfile_auto_imports = { config.debugfile_auto_imports, "s", true },
 			terminal_keymaps = { config.terminal_keymaps, "function", true },
+			terminal_winfixbuf = { config.terminal_winfixbuf, "b", true },
 			completion = { config.completion, "table", true },
 		})
 		if config.completion and config.completion.engine_priority ~= nil then

--- a/lua/ipybridge/session.lua
+++ b/lua/ipybridge/session.lua
@@ -280,6 +280,7 @@ function Session:open(state, go_back, cb, opts)
 			on_exit = state._handle_term_exit,
 			win_id = opts.win_id,
 			cleanup_buf = opts.cleanup_buf,
+			winfixbuf = state.config.terminal_winfixbuf,
 		})
 
 		self:reset_state(state)

--- a/lua/ipybridge/term_ipy.lua
+++ b/lua/ipybridge/term_ipy.lua
@@ -1,6 +1,7 @@
 -- Thin wrapper around a dedicated terminal buffer used to host IPython.
 -- Handles OSC parsing, split/window/bookkeeping, and message dispatch to the
 -- rest of the plugin, with optional reuse of an existing window on restart.
+-- Supports optional window pinning via 'winfixbuf' to prevent buffer replacement.
 -- Neovim 0.11+ is required by the plugin entry.
 -- This module assumes those APIs are available.
 local vim = vim
@@ -52,6 +53,7 @@ function TermIpy:new(cmd, cwd, opts)
 	opts = opts or {}
 	tb._on_message = opts.on_message or default_on_message
 	tb._env = opts.env
+	tb._winfixbuf = opts.winfixbuf == true
 	-- Allow callers to react when the terminal job terminates (e.g. user typed exit).
 	tb._on_exit = opts.on_exit
 	tb._on_stdout_chunk = opts.on_stdout_chunk or noop
@@ -120,6 +122,16 @@ function TermIpy:show()
 		vim.cmd(split_cmd)
 		self.win_id = api.nvim_get_current_win()
 		api.nvim_set_current_buf(self.buf_id)
+		self:__apply_window_options(self.win_id)
+	end
+end
+
+function TermIpy:__apply_window_options(win_id)
+	if not win_id or not api.nvim_win_is_valid(win_id) then
+		return
+	end
+	if self._winfixbuf then
+		api.nvim_set_option_value("winfixbuf", true, { win = win_id })
 	end
 end
 
@@ -171,6 +183,7 @@ function TermIpy:__spawn(cmd, cwd, opts)
 		self.win_id = api.nvim_get_current_win()
 		spawn_in_current()
 	end
+	self:__apply_window_options(self.win_id)
 	self:__cleanup_buffer(cleanup_buf)
 end
 

--- a/tests/spec/term_ipy_spec.lua
+++ b/tests/spec/term_ipy_spec.lua
@@ -29,6 +29,7 @@ end
 local function fresh_term(opts)
 	package.loaded["ipybridge.term_ipy"] = nil
 	local env = mock_vim.new()
+	local option_calls = {}
 	_G.vim = env.vim
 	vim.NIL = json.NIL
 	-- Provide minimal api/fn tables required by term_ipy
@@ -55,6 +56,9 @@ local function fresh_term(opts)
 		nvim_set_current_buf = function() end,
 		nvim_win_close = function() end,
 		nvim_chan_send = function() end,
+		nvim_set_option_value = function(name, value, opt)
+			table.insert(option_calls, { name = name, value = value, opts = opt })
+		end,
 	}
 	vim.json = {
 		decode = function(str)
@@ -68,6 +72,7 @@ local function fresh_term(opts)
 		end,
 	}
 	vim.cmd = function() end
+	env.option_calls = option_calls
 	local term_mod = require("ipybridge.term_ipy")
 	local term = term_mod.TermIpy:new("dummy", ".", opts)
 	return env, term
@@ -103,6 +108,20 @@ it("buffers partial OSC payload until complete", function()
 	assert(#seen == 1, "message not delivered after completion")
 	assert(seen[1].tag == "preview", "tag mismatch after completion")
 	assert(seen[1].data.ok == true, "payload mismatch after completion")
+end)
+
+it("enables winfixbuf when requested", function()
+	local env = fresh_term({ winfixbuf = true })
+	assert(#env.option_calls == 1, "expected winfixbuf to be set once")
+	local call = env.option_calls[1]
+	assert(call.name == "winfixbuf", "expected winfixbuf option")
+	assert(call.value == true, "expected winfixbuf enabled")
+	assert(type(call.opts) == "table" and call.opts.win == 1, "expected window-scoped option")
+end)
+
+it("skips winfixbuf when disabled", function()
+	local env = fresh_term()
+	assert(#env.option_calls == 0, "expected no window options when disabled")
 end)
 
 it("skips invalid JSON payloads with warning", function()


### PR DESCRIPTION
#Summary
- Add terminal_winfixbuf config to lock the IPython terminal window buffer.
- Apply winfixbuf when creating or re-showing the terminal window.

fixes #21